### PR TITLE
Adding pre-commit config for black

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.7


### PR DESCRIPTION
Per @twinters - we can install the [pre-commit](https://pre-commit.com/#install) tool and have it update your local repo pre-commit hooks with the (included in this commit) .pre-commit-config.yml

>  \# from working directory
> brew install pre-commit
> pre-commit install